### PR TITLE
Add minimal server project and heartbeat endpoint

### DIFF
--- a/HeartbeatEndpoint.cs
+++ b/HeartbeatEndpoint.cs
@@ -1,0 +1,7 @@
+public static class HeartbeatEndpoint
+{
+    public static void MapHeartbeatEndpoint(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/heartbeat", () => Results.Ok("alive"));
+    }
+}

--- a/IdlePartyServer.csproj
+++ b/IdlePartyServer.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,7 @@
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.MapHeartbeatEndpoint();
+
+app.Run();


### PR DESCRIPTION
## Summary
- create first `IdlePartyServer.csproj`
- add minimal `Program.cs`
- implement `HeartbeatEndpoint` extension method for a `/heartbeat` route

## Testing
- `dotnet build IdlePartyServer.csproj` *(fails: dotnet not installed)*